### PR TITLE
resolved 'TopLevelAwait' issue during build

### DIFF
--- a/map-with-geojson/vite.config.js
+++ b/map-with-geojson/vite.config.js
@@ -21,6 +21,7 @@ export default defineConfig({
   build: {
     outDir: "./build",
     commonjsOptions: { include: [] },
+    target: "esnext"
   },
   optimizeDeps: {
     disabled: false,

--- a/map-with-markers/vite.config.js
+++ b/map-with-markers/vite.config.js
@@ -21,6 +21,7 @@ export default defineConfig({
   build: {
     outDir: "./build",
     commonjsOptions: { include: [] },
+    target: "esnext"
   },
   optimizeDeps: {
     disabled: false,


### PR DESCRIPTION
*Issue #, if available:*
When running `npm run build` via build script, the build fails due to use of TopLevelAwait in `App.jsx`

*Description of changes:*
Added `build.target = "esnext"` in `vite.config.js` to resolve this build error


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
