### PR TITLE
Modify unauth role to restrict identity pool.

### DIFF
--- a/map-with-amplify/cloudformation/template.yaml
+++ b/map-with-amplify/cloudformation/template.yaml
@@ -43,6 +43,8 @@ Resources:
         Statement:
           - Action: "sts:AssumeRoleWithWebIdentity"
             Condition:
+              "StringEquals":
+                "cognito-identity.amazonaws.com:aud": !Ref CognitoIdentityPool
               "ForAnyValue:StringLike":
                 "cognito-identity.amazonaws.com:amr": unauthenticated
             Effect: Allow

--- a/map-with-geojson/cloudformation/template.yaml
+++ b/map-with-geojson/cloudformation/template.yaml
@@ -43,6 +43,8 @@ Resources:
         Statement:
           - Action: "sts:AssumeRoleWithWebIdentity"
             Condition:
+              "StringEquals":
+                "cognito-identity.amazonaws.com:aud": !Ref CognitoIdentityPool
               "ForAnyValue:StringLike":
                 "cognito-identity.amazonaws.com:amr": unauthenticated
             Effect: Allow

--- a/map-with-markers/cloudformation/template.yaml
+++ b/map-with-markers/cloudformation/template.yaml
@@ -43,6 +43,8 @@ Resources:
         Statement:
           - Action: "sts:AssumeRoleWithWebIdentity"
             Condition:
+              "StringEquals":
+                "cognito-identity.amazonaws.com:aud": !Ref CognitoIdentityPool
               "ForAnyValue:StringLike":
                 "cognito-identity.amazonaws.com:amr": unauthenticated
             Effect: Allow


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Automated checks flagged the Unauth roles for not specifying the specific identity pool associated with the role. This adds the identity pool check. The resulting behavior should effectively be identical, but it now checks that credentials are issued to users of the intended Cognito Identity Pool.

Tested by submitting template.yaml files manually to CloudFormation. Results as follows (ids redacted):
```
Map-with-amplify template.yaml:
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Principal": {
                "Federated": "cognito-identity.amazonaws.com"
            },
            "Action": "sts:AssumeRoleWithWebIdentity",
            "Condition": {
                "StringEquals": {
                    "cognito-identity.amazonaws.com:aud": "us-east-1:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
                },
                "ForAnyValue:StringLike": {
                    "cognito-identity.amazonaws.com:amr": "unauthenticated"
                }
            }
        }
    ]
}

Map-with-geojson template.yaml:
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Principal": {
                "Federated": "cognito-identity.amazonaws.com"
            },
            "Action": "sts:AssumeRoleWithWebIdentity",
            "Condition": {
                "StringEquals": {
                    "cognito-identity.amazonaws.com:aud": "us-east-1:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
                },
                "ForAnyValue:StringLike": {
                    "cognito-identity.amazonaws.com:amr": "unauthenticated"
                }
            }
        }
    ]
}

Map-with-markers template.yaml:
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Principal": {
                "Federated": "cognito-identity.amazonaws.com"
            },
            "Action": "sts:AssumeRoleWithWebIdentity",
            "Condition": {
                "StringEquals": {
                    "cognito-identity.amazonaws.com:aud": "us-east-1:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
                },
                "ForAnyValue:StringLike": {
                    "cognito-identity.amazonaws.com:amr": "unauthenticated"
                }
            }
        }
    ]
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
