### PR TITLE
Adding IoT and Analytics Components to align with IoT Solutions Guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains a set of sample applications for Amazon Location Servic
 - [Display a web map using Amplify](map-with-amplify/)
 - [Display GeoJSON on a web map](map-with-geojson/)
 - [Display markers on a web map](map-with-markers/)
-- [Stream device positions, display device and geofence breaching notifications on a web map](tracking-data-streaming/)
+- [Stream device positions, display device and geofence breaching notifications on a web map](tracking-data-streaming/) 
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains a set of sample applications for Amazon Location Servic
 - [Display a web map using Amplify](map-with-amplify/)
 - [Display GeoJSON on a web map](map-with-geojson/)
 - [Display markers on a web map](map-with-markers/)
-- [Stream device positions, display device and geofence breaching notifications on a web map](tracking-data-streaming/) 
+- [Stream device positions, display device and geofence breaching notifications on a web map](tracking-data-streaming/)
 
 ## Security
 

--- a/tracking-data-streaming/README.md
+++ b/tracking-data-streaming/README.md
@@ -59,7 +59,8 @@ This sample app uses two [Unauthenticated Cognito Identity Pool roles](https://d
 2. A write-only role which allows only write access such as `geo:PutGeofence` and `kinesis:PutRecords`, etc.
 
 The separation follows the [Principle of Least Privilege](https://en.wikipedia.org/wiki/Principle_of_least_privilege).
-
+## IoT and Analytics Integration
+This sample can be integrated with AWS IoT Core and AWS Analytics services as demonstrated in [Guidance for Tracking Assets & Locating Devices Using AWS IoT](https://aws.amazon.com/solutions/guidance/tracking-assets-and-locating-devices-using-aws-iot/). To track positions using AWS IoT Core, modify the `./deploy_cloudformation` file and set the `DeployIoT` variable to `true`. To enable location updates being sent to Amazon S3 for analtyics, modify `./deploy_cloudformation` and set the `DeployAnalytics` variable to `true`
 ## Security
 
 See [CONTRIBUTING](./CONTRIBUTING.md#security-issue-notifications) for more information.

--- a/tracking-data-streaming/deploy_cloudformation.sh
+++ b/tracking-data-streaming/deploy_cloudformation.sh
@@ -3,6 +3,11 @@
 # Configurable variables
 TrackerName="SampleTracker"
 
+# Choose true to deploy IoT Core Rules to send Location Updates from the MQTT Topic 'location'. Default value false.
+DeployIoT=false
+# Choose true to deploy additional resources to enable Location Updates to be sent to S3 for long term storage and analysis. Default value false.
+DeployAnalytics=false
+
 # SAR application id for kinesis-stream-device-data-to-amazon-location-tracker app
 ApplicationId="arn:aws:serverlessrepo:us-east-1:003883091127:applications/kinesis-stream-device-data-to-amazon-location-tracker"
 
@@ -96,5 +101,29 @@ aws cloudformation deploy \
   --parameter-overrides TrackerName=${TrackerName} \
   --region ${AWS_REGION} \
   --capabilities CAPABILITY_NAMED_IAM
+
+
+
+if $DeployIoT
+then
+  echo "Deploying cloudformation template for IoT Sample app using TrackerName: $TrackerName and region: $AWS_REGION."
+  aws cloudformation deploy \
+  --template-file src/cfn_template/iotResources.yml \
+  --stack-name TrackingAndGeofencingSampleIoT \
+  --parameter-overrides TrackerName=${TrackerName} \
+  --region ${AWS_REGION} \
+  --capabilities CAPABILITY_NAMED_IAM
+fi
+
+if $DeployAnalytics
+then
+  echo "Deploying cloudformation template for Analytics Sample app using TrackerName: $TrackerName and region: $AWS_REGION."
+  aws cloudformation deploy \
+  --template-file src/cfn_template/analyticsResources.yml \
+  --stack-name TrackingAndGeofencingSampleAnalytics \
+  --parameter-overrides TrackerName=${TrackerName} \
+  --region ${AWS_REGION} \
+  --capabilities CAPABILITY_NAMED_IAM
+fi
 
 echo "All deployments complete!"

--- a/tracking-data-streaming/src/cfn_template/analyticsResources.yml
+++ b/tracking-data-streaming/src/cfn_template/analyticsResources.yml
@@ -1,0 +1,106 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: A Template to provision AWS Analytics Resources for the Amazon Location Live Device Tracking and Geofencing sample app.
+Parameters:
+  TrackerName:
+    Type: String
+    Description: Name of the Amazon Location Tracker to use.
+Resources:
+  TrackingAndGeofencingSampleAnalyticsBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+
+  TrackingAndGeofencingSampleAnalyticsDeliveryStreamRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: firehose.amazonaws.com
+            Action: 'sts:AssumeRole'
+            Condition:
+              StringEquals:
+                'sts:ExternalId': !Ref 'AWS::AccountId'
+      Policies:
+        - PolicyName: firehose-s3-policy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - 's3:AbortMultipartUpload'
+                  - 's3:GetBucketLocation'
+                  - 's3:GetObject'
+                  - 's3:ListBucket'
+                  - 's3:ListBucketMultipartUploads'
+                  - 's3:PutObject'
+                Resource:
+                  - !GetAtt TrackingAndGeofencingSampleAnalyticsBucket.Arn
+                  - !Join ['', [!GetAtt TrackingAndGeofencingSampleAnalyticsBucket.Arn, '/*']]
+
+  TrackingAndGeofencingSampleAnalyticsDeliveryStream:
+    Type: AWS::KinesisFirehose::DeliveryStream
+    Properties:
+      DeliveryStreamName: TrackingAndGeofencingSampleAnalyticsDeliveryStream
+      DeliveryStreamType: DirectPut
+      ExtendedS3DestinationConfiguration:
+        BucketARN: !GetAtt TrackingAndGeofencingSampleAnalyticsBucket.Arn
+        BufferingHints:
+          IntervalInSeconds: 60
+          SizeInMBs: 1
+        CompressionFormat: UNCOMPRESSED
+        RoleARN: !GetAtt TrackingAndGeofencingSampleAnalyticsDeliveryStreamRole.Arn
+        CloudWatchLoggingOptions:
+          Enabled: true
+          LogGroupName: !Join ['-', ['/aws/kinesisfirehose/', 'TrackingAndGeofencingSampleAnalyticsDeliveryStream']]
+          LogStreamName: S3Delivery
+
+  TrackingAndGeofencingSampleAnalyticsEventBridgeRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: !Sub events.amazonaws.com
+            Action: 'sts:AssumeRole'
+      Path: /
+      Policies:
+        - PolicyName: EventBridgeInvokeKinesis
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "firehose:PutRecord"
+                  - "firehose:PutRecords"
+                Resource:
+                  - !GetAtt TrackingAndGeofencingSampleAnalyticsDeliveryStream.Arn
+                  
+  
+  
+  
+  TrackingAndGeofencingSampleAnalyticsEventBridgeRule:
+    Type: AWS::Events::Rule
+    Properties:
+      Description: EventBridge Rule for Amazon Location Service Tracker Events
+      EventPattern:
+        source:
+          - aws.geo
+        detail-type:
+          - "Location Device Position Event"
+        detail:
+          TrackerName:
+          - !Ref TrackerName
+      Name: TrackingAndGeofencingSampleAnalyticsEventBridgeRule
+      Targets:
+        -
+          Arn: !GetAtt TrackingAndGeofencingSampleAnalyticsDeliveryStream.Arn
+          RoleArn: !GetAtt TrackingAndGeofencingSampleAnalyticsEventBridgeRole.Arn
+          Id: 1

--- a/tracking-data-streaming/src/cfn_template/iotResources.yml
+++ b/tracking-data-streaming/src/cfn_template/iotResources.yml
@@ -1,0 +1,114 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: A Template to provision AWS IoT Core Resources for the Amazon Location Live Device Tracking and Geofencing sample app.
+Parameters:
+  TrackerName:
+    Type: String
+    Description: Name of the Amazon Location Tracker to use.
+Resources:
+  TrackingAndGeofencingSampleIoTLambdaFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service:
+            - lambda.amazonaws.com
+          Action:
+          - sts:AssumeRole
+      Path: "/"
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+      - PolicyName: TrackingAndGeofencingSampleIoTLambdaFunctionPolicy
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - geo:BatchUpdateDevicePosition
+            Resource: !Sub 
+              - 'arn:aws:geo:${AWS::Region}:${AWS::AccountId}:tracker/${TrackerName}'
+              - TrackerName: !Ref TrackerName
+
+  TrackingAndGeofencingSampleIoTLambdaFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      Runtime: python3.12
+      FunctionName: TrackingAndGeofencingSampleIoTLambdaFunction
+      Role: !GetAtt TrackingAndGeofencingSampleIoTLambdaFunctionRole.Arn
+      Environment:
+        Variables:
+          TrackerName: !Ref TrackerName
+      Handler: index.lambda_handler
+      Code:
+        ZipFile: |
+          from datetime import datetime
+          import json
+          import os
+
+          import boto3
+
+          # Update this to match the name of your Tracker resource
+          TRACKER_NAME = os.environ['TrackerName']
+
+          """
+          This Lambda function receives a payload from AWS IoT Core and publishes device updates to 
+          Amazon Location Service via the BatchUpdateDevicePosition API.
+
+          Parameter 'event' is the payload delivered from AWS IoT Core.
+
+          In this sample, we assume that the payload has a single top-level key 'payload' and a nested key
+          'location' with keys 'lat' and 'long'. We also assume that the name of the device is nested in
+          the payload as 'deviceid'. Finally, the timestamp of the payload is present as 'timestamp'. For
+          example:
+
+          >>> event
+          { 'payload': { 'deviceid': 'thing123', 'timestamp': 1604940328,
+            'location': { 'lat': 49.2819, 'long': -123.1187 },
+            'accuracy': {'Horizontal': 20.5 },
+            'positionProperties': {'field1':'value1','field2':'value2'} }
+          }
+
+          If your data doesn't match this schema, you can either use the AWS IoT Core rules engine to
+          format the data before delivering it to this Lambda function, or you can modify the code below to
+          match it.
+          """
+          def lambda_handler(event, context):
+            update = {
+                "DeviceId": event["payload"]["deviceid"],
+                "SampleTime": datetime.fromtimestamp(event["payload"]["timestamp"]).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "Position": [
+                  event["payload"]["location"]["long"],
+                  event["payload"]["location"]["lat"]
+                  ]
+              }
+            if "accuracy" in event["payload"]:
+                update["Accuracy"] = event["payload"]['accuracy']
+            if "positionProperties" in event["payload"]:
+                update["PositionProperties"] = event["payload"]['positionProperties']
+          
+            client = boto3.client("location")
+            response = client.batch_update_device_position(TrackerName=TRACKER_NAME, Updates=[update])
+
+            return {
+              "statusCode": 200,
+              "body": json.dumps(response)
+            }
+  TrackingAndGeofencingSampleIoTCoreRule:
+    Type: AWS::IoT::TopicRule
+    Properties:
+      RuleName: UpdateLocationTrackerFromMQTT
+      TopicRulePayload:
+        Description: Rule to send MQTT messages to Amazon Location Service Tracker
+        Sql: "SELECT * FROM 'location'"
+        Actions:
+          - Lambda:
+              FunctionArn: !GetAtt TrackingAndGeofencingSampleIoTLambdaFunction.Arn
+  TrackingAndGeofencingSampleIoTLambdaPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref TrackingAndGeofencingSampleIoTLambdaFunction
+      Principal: iot.amazonaws.com


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change adds two CFN templates for an IoT Rule and associated IAM resources to send location updates from MQTT to Amazon Location Service Trackers. In addition it adds an S3 bucket, Kinesis firehose stream, and Eventbridge rule that sends data to Amazon S3 for analytics workloads.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
