### PR TITLE
refactor: remove top-level await for `withIdentityPoolId`

### DIFF
--- a/tracking-data-streaming/src/App.jsx
+++ b/tracking-data-streaming/src/App.jsx
@@ -27,10 +27,27 @@ import { withIdentityPoolId } from "@aws/amazon-location-utilities-auth-helper";
 import "./index.css";
 
 // As a best practice, splitting out the Read permissions to a readOnly role so that customers' permissions are strictly separate from system admin's.
-const readOnlyAuthHelper = await withIdentityPoolId(READ_ONLY_IDENTITY_POOL_ID);
-const writeOnlyAuthHelper = await withIdentityPoolId(WRITE_ONLY_IDENTITY_POOL_ID);
+let authHelpers = {
+  readOnly: undefined,
+  writeOnly: undefined,
+};
+
+const getAuthHelpers = async () => {
+  if (!authHelpers.readOnlyAuthHelper) {
+    authHelpers.readOnlyAuthHelper = await withIdentityPoolId(
+      READ_ONLY_IDENTITY_POOL_ID
+    );
+  }
+  if (!authHelpers.writeOnlyAuthHelper) {
+    authHelpers.writeOnlyAuthHelper = await withIdentityPoolId(
+      WRITE_ONLY_IDENTITY_POOL_ID
+    );
+  }
+  return authHelpers;
+};
 
 const App = () => {
+  const [readOnlyAuthHelper, setReadOnlyAuthHelper] = useState();
   const [readOnlyRoleCredentials, setReadOnlyRoleCredentials] = useState();
   const [writeOnlyRoleCredentials, setWriteOnlyRoleCredentials] = useState();
   const [readOnlyLocationClient, setReadOnlyLocationClient] = useState();
@@ -45,8 +62,14 @@ const App = () => {
   //Fetch writeOnlyRoleCredentials when the app loads
   useEffect(() => {
     const fetchCredentials = async () => {
-      setReadOnlyRoleCredentials(readOnlyAuthHelper.getLocationClientConfig);
-      setWriteOnlyRoleCredentials(writeOnlyAuthHelper.getLocationClientConfig());
+      const authHelpers = await getAuthHelpers();
+      setReadOnlyRoleCredentials(
+        authHelpers.readOnlyAuthHelper.getLocationClientConfig
+      );
+      setWriteOnlyRoleCredentials(
+        authHelpers.writeOnlyAuthHelper.getLocationClientConfig()
+      );
+      setReadOnlyAuthHelper(authHelpers.readOnlyAuthHelper);
     };
     fetchCredentials();
   }, []);


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* This PR refactors the portion of code that called the `withIdentityPoolId` helpers using top-level `await`.

This change was necessary because attempting to build the project using `npm run build` would cause a transform error:
```sh
error during build:
Error: Transform failed with 2 errors:
assets/index-!~{001}~.js:31113:27: ERROR: Top-level await is not available in the configured target environment ("chrome87", "edge88", "es2020", "firefox78", "safari14" + 3 overrides)
assets/index-!~{001}~.js:31114:28: ERROR: Top-level await is not available in the configured target environment ("chrome87", "edge88", "es2020", "firefox78", "safari14" + 3 overrides)
    at failureErrorWithLog (/Users/aamorosi/Codes/amazon-location-samples-react/tracking-data-streaming/node_modules/esbuild/lib/main.js:1649:15)
    at /Users/aamorosi/Codes/amazon-location-samples-react/tracking-data-streaming/node_modules/esbuild/lib/main.js:847:29
    at responseCallbacks.<computed> (/Users/aamorosi/Codes/amazon-location-samples-react/tracking-data-streaming/node_modules/esbuild/lib/main.js:703:9)
    at handleIncomingPacket (/Users/aamorosi/Codes/amazon-location-samples-react/tracking-data-streaming/node_modules/esbuild/lib/main.js:762:9)
    at Socket.readFromStdout (/Users/aamorosi/Codes/amazon-location-samples-react/tracking-data-streaming/node_modules/esbuild/lib/main.js:679:7)
    at Socket.emit (node:events:518:28)
    at addChunk (node:internal/streams/readable:559:12)
    at readableAddChunkPushByteMode (node:internal/streams/readable:510:3)
    at Readable.push (node:internal/streams/readable:390:5)
```

Changing the build target to something that supports top-level await like `es2022` or `esnext` does remove the transform error, but generates a build that doesn't work on Chrome nor Firefox (blank page, no errors).

The refactor addresses the issue while leaving the overall functioning unchanged.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
