### PR TITLE
Update tracker to poll device positions on Tracker panel

### DIFF
--- a/tracking-data-streaming/src/components/trackers/TrackersLayer.jsx
+++ b/tracking-data-streaming/src/components/trackers/TrackersLayer.jsx
@@ -227,11 +227,25 @@ const TrackersLayer = ({
 
   useEffect(() => {
     let cleanupSqs;
-    let cleanupDevicePositionPoll;
 
     const startPolling = async () => {
       if (isRunningDemo) {
         cleanupSqs = await startPollingSQS();
+      }
+    };
+
+    startPolling();
+
+    return () => {
+      if (cleanupSqs) cleanupSqs();
+    };
+  }, [isRunningDemo]);
+
+  useEffect(() => {
+    let cleanupDevicePositionPoll;
+
+    const startPolling = async () => {
+      if (isOpenedPanel) {
         cleanupDevicePositionPoll = await startPollingDevicePosition();
       }
     };
@@ -239,11 +253,9 @@ const TrackersLayer = ({
     startPolling();
 
     return () => {
-      // These functions will be called when the component unmounts or before the effect runs again.
-      if (cleanupSqs) cleanupSqs();
       if (cleanupDevicePositionPoll) cleanupDevicePositionPoll();
     };
-  }, [isRunningDemo]);
+  }, [isOpenedPanel]);
 
   const handleViewDeviceHistory = (deviceId) => {
     // Specify which device to look into for the history


### PR DESCRIPTION
Now the demo polls device positions on Tracker panel instead of only when the demo is running.

*Issue #, if available:*
None

*Description of changes:*
Based on feedback from @zachelliottwx, it is better to poll device positions when the user stays on the Tracker panel, instead of only when the demo is running.

*Testing*
Run the demo locally with `npm start`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
