### PR TITLE
Updated launch stack template links

### DIFF
--- a/map-with-geojson/README.md
+++ b/map-with-geojson/README.md
@@ -6,7 +6,7 @@ This example demonstrates how to display GeoJSON on a web map using [React](http
 
 Click the button below to create the necessary AWS resources for this sample app to run. It will open the AWS Management Console and initiate the CloudFormation template deployment process.
 
-[![Launch Stack](https://amazon-location-cloudformation-templates.s3.us-west-2.amazonaws.com/cfn-launch-stack-button.svg)](https://console.aws.amazon.com/cloudformation/home?#/stacks/quickcreate?stackName=react-map-with-geojson-example&templateURL=https://amazon-location-sample-resources.s3.us-west-2.amazonaws.com/react-map-with-geojson/cloudformation/template.yaml)
+[![Launch Stack](https://amazon-location-sample-resources.s3.us-west-2.amazonaws.com/cfn-launch-stack-button.svg)](https://console.aws.amazon.com/cloudformation/home?#/stacks/quickcreate?stackName=react-map-with-geojson-example&templateURL=https://amazon-location-sample-resources.s3.us-west-2.amazonaws.com/react-map-with-geojson/cloudformation/template.yaml)
 
 Once the deployment process is complete, go to the **Outputs** section to get the Amazon Location Maps ApiKey, AWS Region.
 

--- a/map-with-geojson/README.md
+++ b/map-with-geojson/README.md
@@ -6,7 +6,7 @@ This example demonstrates how to display GeoJSON on a web map using [React](http
 
 Click the button below to create the necessary AWS resources for this sample app to run. It will open the AWS Management Console and initiate the CloudFormation template deployment process.
 
-[![Launch Stack](https://amazon-location-cloudformation-templates.s3.us-west-2.amazonaws.com/cfn-launch-stack-button.svg)](https://console.aws.amazon.com/cloudformation/home?#/stacks/quickcreate?stackName=react-map-with-geojson-example&templateURL=https://amazon-location-cloudformation-templates.s3.us-west-2.amazonaws.com/samples/web-react-map-with-geojson/template.yaml)
+[![Launch Stack](https://amazon-location-cloudformation-templates.s3.us-west-2.amazonaws.com/cfn-launch-stack-button.svg)](https://console.aws.amazon.com/cloudformation/home?#/stacks/quickcreate?stackName=react-map-with-geojson-example&templateURL=https://amazon-location-sample-resources.s3.us-west-2.amazonaws.com/react-map-with-geojson/cloudformation/template.yaml)
 
 Once the deployment process is complete, go to the **Outputs** section to get the Amazon Location Maps ApiKey, AWS Region.
 

--- a/map-with-markers/README.md
+++ b/map-with-markers/README.md
@@ -6,7 +6,7 @@ This example demonstrates how to display markers on a web map using [React](http
 
 Click the button below to create the necessary AWS resources for this sample app to run. It will open the AWS Management Console and initiate the CloudFormation template deployment process.
 
-[![Launch Stack](https://amazon-location-cloudformation-templates.s3.us-west-2.amazonaws.com/cfn-launch-stack-button.svg)](https://console.aws.amazon.com/cloudformation/home?#/stacks/quickcreate?stackName=react-map-with-markers-example&templateURL=https://amazon-location-sample-resources.s3.us-west-2.amazonaws.com/react-map-with-markers/cloudformation/template.yaml)
+[![Launch Stack](https://amazon-location-sample-resources.s3.us-west-2.amazonaws.com/cfn-launch-stack-button.svg)](https://console.aws.amazon.com/cloudformation/home?#/stacks/quickcreate?stackName=react-map-with-markers-example&templateURL=https://amazon-location-sample-resources.s3.us-west-2.amazonaws.com/react-map-with-markers/cloudformation/template.yaml)
 
 Once the deployment process is complete, go to the **Outputs** section to get the Amazon Location Maps ApiKey, AWS Region.
 

--- a/map-with-markers/README.md
+++ b/map-with-markers/README.md
@@ -6,7 +6,7 @@ This example demonstrates how to display markers on a web map using [React](http
 
 Click the button below to create the necessary AWS resources for this sample app to run. It will open the AWS Management Console and initiate the CloudFormation template deployment process.
 
-[![Launch Stack](https://amazon-location-cloudformation-templates.s3.us-west-2.amazonaws.com/cfn-launch-stack-button.svg)](https://console.aws.amazon.com/cloudformation/home?#/stacks/quickcreate?stackName=react-map-with-markers-example&templateURL=https://amazon-location-cloudformation-templates.s3.us-west-2.amazonaws.com/samples/web-react-map-with-markers/template.yaml)
+[![Launch Stack](https://amazon-location-cloudformation-templates.s3.us-west-2.amazonaws.com/cfn-launch-stack-button.svg)](https://console.aws.amazon.com/cloudformation/home?#/stacks/quickcreate?stackName=react-map-with-markers-example&templateURL=https://amazon-location-sample-resources.s3.us-west-2.amazonaws.com/react-map-with-markers/cloudformation/template.yaml)
 
 Once the deployment process is complete, go to the **Outputs** section to get the Amazon Location Maps ApiKey, AWS Region.
 


### PR DESCRIPTION
### Description
Updated the launch stack cloud formation template links for `map-with-geojson` and `map-with-markers` samples.

Fixes #61 

### Testing
Click launch stack button and verified it now creates a stack from the proper template.