### PR TITLE
Removed 18.x from node matrix and added 24.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         package:
           ["map-with-geojson", "map-with-markers", "tracking-data-streaming"]
-        node-version: ["18.x", "20.x", "22.x"]
+        node-version: ["20.x", "22.x", "24.x"]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
### Description
Removed node `18.x` from our CI node version matrix and added `24.x`. We started seeing some CI failures (https://github.com/aws-geospatial/amazon-location-samples-react/pull/133) due to EOL node versions. Node `18.x` has been EOL since March of 2025, so it is safe to remove. Also added `24.x` since it is current LTS.